### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v1
+      - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: NotionRepackaged.NotionEnhanced
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,16 @@
+name: Publish to WinGet
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: NotionRepackaged.NotionEnhanced
+          version-regex: '[\d.-]+'
+          installers-regex: 'Notion-Enhanced-Setup-*.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -8,9 +8,7 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: NotionRepackaged.NotionEnhanced
-          version-regex: '[\d.-]+'
-          installers-regex: 'Notion-Enhanced-Setup-*.exe$'
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: NotionRepackaged.NotionEnhanced
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
[This action](https://github.com/vedantmgoyal2009/winget-releaser) automatically generates manifests for WinGet Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

[Notion Enhanced](https://github.com/microsoft/winget-pkgs/tree/master/manifests/n/NotionRepackaged/NotionEnhanced) is already in Winget, and this workflow will be used to update it.

**Before merging this:**
1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`. You can go to this URL to create it: https://github.com/settings/tokens/new?scopes=public_repo

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @notion-enhancer. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Use [Pull](https://github.com/apps/pull) to ensure the fork is constantly updated.

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).
